### PR TITLE
Refine hero content for pragmatic AI consultancy messaging

### DIFF
--- a/css/templatemo-style.css
+++ b/css/templatemo-style.css
@@ -177,6 +177,54 @@ section {
     filter: drop-shadow(0 10px 25px rgba(156, 39, 176, 0.5));
 }
 
+.hero-checklist li {
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 1.05rem;
+    margin-bottom: 0.75rem;
+}
+
+.hero-checklist li:last-child {
+    margin-bottom: 0;
+}
+
+.hero-outcomes {
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(18px);
+}
+
+.hero-outcome-icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    background: rgba(13, 110, 253, 0.18);
+    color: #0d6efd;
+}
+
+.hero-outcome-icon.success {
+    background: rgba(25, 135, 84, 0.18);
+    color: #198754;
+}
+
+.hero-outcome-icon.warning {
+    background: rgba(255, 193, 7, 0.2);
+    color: #ffc107;
+}
+
+.hero-outcomes-footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.hero-outcomes-footer .btn {
+    border-radius: 12px;
+    padding: 0.75rem 1.5rem;
+}
+
 /* AI Theme Colors */
 :root {
     --ai-primary: #9C27B0;
@@ -619,7 +667,11 @@ section {
         text-align: center;
         padding: 150px 0 80px;
     }
-    
+
+    .hero-outcomes {
+        margin-top: 3rem;
+    }
+
     .navbar-collapse {
         background-color: rgba(23, 25, 28, 0.95);
         padding: 1rem;
@@ -678,6 +730,12 @@ section {
     
     .tech-icon.ai-core i {
         font-size: 2.5rem;
+    }
+
+    .hero-outcome-icon {
+        width: 44px;
+        height: 44px;
+        font-size: 1.1rem;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -48,18 +48,65 @@
     <!-- Hero Section -->
     <section id="home" class="hero-section">
         <div class="container">
-            <div class="row align-items-center justify-content-center text-center min-vh-100">
-                <div class="col-lg-8" data-aos="fade-up">
-                    <h1 class="display-3 fw-bold mb-2">AI-consultancy voor realistische verbeteringen</h1>
-                    <p class="lead mb-3">Pragmatische ondersteuning voor teams die AI verantwoord willen inzetten.</p>
-                    <ul class="list-unstyled mb-4">
-                        <li class="mb-1">Werkbare AI-roadmaps</li>
-                        <li class="mb-1">Proof-of-concepts in weken</li>
-                        <li>Inbedden van AI in bestaande processen</li>
+            <div class="row align-items-center min-vh-100">
+                <div class="col-lg-6 text-center text-lg-start" data-aos="fade-right">
+                    <h1 class="display-3 fw-bold mb-3">AI-consultancy voor realistische verbeteringen</h1>
+                    <p class="lead mb-4">Pragmatische ondersteuning voor teams die AI verantwoord willen inzetten.</p>
+                    <ul class="list-unstyled hero-checklist mb-4">
+                        <li class="d-flex align-items-start justify-content-center justify-content-lg-start">
+                            <i class="fas fa-check-circle text-success me-2 mt-1"></i>
+                            <span>Werkbare AI-roadmaps en haalbaarheidsanalyse</span>
+                        </li>
+                        <li class="d-flex align-items-start justify-content-center justify-content-lg-start">
+                            <i class="fas fa-check-circle text-success me-2 mt-1"></i>
+                            <span>Proof-of-concepts met meetbare KPI's binnen weken</span>
+                        </li>
+                        <li class="d-flex align-items-start justify-content-center justify-content-lg-start">
+                            <i class="fas fa-check-circle text-success me-2 mt-1"></i>
+                            <span>Integratieplannen die aansluiten op bestaande processen</span>
+                        </li>
                     </ul>
-                    <div class="d-flex justify-content-center">
-                        <a href="#contact" class="btn btn-primary btn-lg me-2">Plan een gesprek</a>
+                    <div class="d-flex flex-column flex-sm-row justify-content-center justify-content-lg-start">
+                        <a href="#contact" class="btn btn-primary btn-lg me-sm-3 mb-3 mb-sm-0">Plan een gesprek</a>
                         <a href="#services" class="btn btn-outline-light">Onze Diensten</a>
+                    </div>
+                </div>
+                <div class="col-lg-5 offset-lg-1 mt-5 mt-lg-0" data-aos="fade-left">
+                    <div class="hero-outcomes card border-0 shadow-lg">
+                        <div class="card-body p-4 p-lg-5">
+                            <h6 class="text-uppercase text-white-50 mb-4">Wat u direct ontvangt</h6>
+                            <div class="d-flex align-items-start mb-4">
+                                <div class="hero-outcome-icon">
+                                    <i class="fas fa-route"></i>
+                                </div>
+                                <div class="ms-3">
+                                    <h5 class="text-white mb-1">AI-roadmap in 4 weken</h5>
+                                    <p class="text-white-50 mb-0 small">Workshops, stakeholder interviews en een stappenplan op maat.</p>
+                                </div>
+                            </div>
+                            <div class="d-flex align-items-start mb-4">
+                                <div class="hero-outcome-icon success">
+                                    <i class="fas fa-rocket"></i>
+                                </div>
+                                <div class="ms-3">
+                                    <h5 class="text-white mb-1">Proof-of-concept met metrics</h5>
+                                    <p class="text-white-50 mb-0 small">Prototype met technische validatie en businesscase onderbouwing.</p>
+                                </div>
+                            </div>
+                            <div class="d-flex align-items-start">
+                                <div class="hero-outcome-icon warning">
+                                    <i class="fas fa-diagram-project"></i>
+                                </div>
+                                <div class="ms-3">
+                                    <h5 class="text-white mb-1">Implementatiehandboek voor teams</h5>
+                                    <p class="text-white-50 mb-0 small">Integratieadvies, governance richtlijnen en change management tips.</p>
+                                </div>
+                            </div>
+                            <div class="hero-outcomes-footer mt-4 pt-3">
+                                <p class="text-white-50 mb-3">Onze consultants blijven betrokken tot de oplossing waarde levert in de praktijk.</p>
+                                <a href="value-proposition/" class="btn btn-outline-primary">Bekijk onze aanpak</a>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -50,15 +50,15 @@
         <div class="container">
             <div class="row align-items-center justify-content-center text-center min-vh-100">
                 <div class="col-lg-8" data-aos="fade-up">
-                    <h1 class="display-3 fw-bold mb-2">Next-Gen AI & Cloud Diensten</h1>
-                    <p class="lead mb-3">Versnel uw innovatie met AI-oplossingen en cloud-technologie die resultaten leveren</p>
-                    <div class="mb-4">
-                        <span class="badge bg-primary me-2 p-2">42% Kostenbesparing</span>
-                        <span class="badge bg-success me-2 p-2">85% Automatisering</span>
-                        <span class="badge bg-info p-2">3x Snellere Implementatie</span>
-                    </div>
+                    <h1 class="display-3 fw-bold mb-2">AI-consultancy voor realistische verbeteringen</h1>
+                    <p class="lead mb-3">Pragmatische ondersteuning voor teams die AI verantwoord willen inzetten.</p>
+                    <ul class="list-unstyled mb-4">
+                        <li class="mb-1">Werkbare AI-roadmaps</li>
+                        <li class="mb-1">Proof-of-concepts in weken</li>
+                        <li>Inbedden van AI in bestaande processen</li>
+                    </ul>
                     <div class="d-flex justify-content-center">
-                        <a href="#contact" class="btn btn-primary btn-lg me-2 pulse-btn">Gratis Consult Aanvragen</a>
+                        <a href="#contact" class="btn btn-primary btn-lg me-2">Plan een gesprek</a>
                         <a href="#services" class="btn btn-outline-light">Onze Diensten</a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Replace hero heading and subtext with concise, pragmatic AI consultancy messaging
- Swap ROI badges for grounded bullet points that highlight tangible deliverables
- Update primary call-to-action text and remove pulse animation for a calmer presentation

## Testing
- No automated tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cafdbc52888325b37a3d229a7629aa