### PR TITLE
ci: add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a checked-in GitHub Pages deployment workflow for the static site
- run on pushes to main and allow manual workflow_dispatch deploys
- keep the deployment artifact as the repository root so CNAME and static HTML are published

## History checked
- .github/workflows/docker-image.yml existed from 2022 and was removed by bb7745e on 2024-01-08
- that old workflow built/pushed a Docker image, not GitHub Pages
- current Pages config uses GitHub's dynamic pages-build-deployment workflow, which did not run for merge commit 29ce28b

## Verification
- inspected Actions workflow history and Pages settings via gh api
- no local build step exists for this static HTML repo

## Risk and rollback
- CI-only change. Revert this commit to return to GitHub's implicit Pages deployment behavior.